### PR TITLE
Close figure after saving to improve memory and speed of similar_images

### DIFF
--- a/similar_images_AE/src/utilities/plot_utilities.py
+++ b/similar_images_AE/src/utilities/plot_utilities.py
@@ -50,3 +50,4 @@ class PlotUtils(object):
             plt.show()
         else:
             plt.savefig(filename, bbox_inches='tight')
+        plt.close()


### PR DESCRIPTION
After approximately 20 images, the code uses a lot of memory (>10GB) and becomes incredibly slow. This is because the figure objects are not closed.